### PR TITLE
linker: allow text relocations on user builds

### DIFF
--- a/linker/Android.mk
+++ b/linker/Android.mk
@@ -54,13 +54,7 @@ ifeq ($(TARGET_IS_64_BIT),true)
 LOCAL_CPPFLAGS += -DTARGET_IS_64_BIT
 endif
 
-ifeq ($(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS),true)
-ifeq ($(user_variant),user)
-$(error Do not enable text relocations on user builds)
-else
 LOCAL_CPPFLAGS += -DTARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS
-endif
-endif
 
 # We need to access Bionic private headers in the linker.
 LOCAL_CFLAGS += -I$(LOCAL_PATH)/../libc/


### PR DESCRIPTION
* This check was originally added to prevent this flag
  from making it in to production builds at inc. We're
  not shipping any production builds and in the interest
  of security regarding userdebug vs user, adb root for
  example, allow building with this flag on more secure
  builds.

Change-Id: I92fadb191d74ccaede175715e9bd42650857ae88
(cherry picked from commit 0178c1ee75ce5bf3f53d678f080200d348f346d0)